### PR TITLE
Make reserved fields use a predefined case

### DIFF
--- a/lib/BagIt.php
+++ b/lib/BagIt.php
@@ -1221,7 +1221,10 @@ class BagIt
                     try {
                         BagItUtils::checkForNonRepeatableBagInfoFields($key, $bagInfo);
                     } catch (BagItException $e) {
-                        $errors[] = $e->getMessage();
+                        $errors[] = [
+                            'bag-info',
+                            $e->getMessage(),
+                        ];
                     }
                     $prevKey=$key;
                     $bagInfo[$prevKey]=BagItUtils::getAccumulatedValue(

--- a/lib/BagItConstants.php
+++ b/lib/BagItConstants.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * This is a PHP implementation of the {@link
+ * https://wiki.ucop.edu/display/Curation/BagIt BagIt specification}. Really,
+ * it is a port of {@link https://github.com/ahankinson/pybagit/ PyBagIt} for
+ * PHP.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless
+ * required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+namespace ScholarsLab\BagIt;
+
+/**
+ * Constants for use through out our BagIt impl.
+ * @package ScholarsLab\BagIt
+ * @author Jared Whiklo <jwhiklo@gmail.com>
+ * @since 2019-10-20
+ */
+class BagItConstants
+{
+
+    /**
+     * Bag-info fields that MUST not be repeated (in lowercase).
+     */
+    const BAG_INFO_MUST_NOT_REPEAT = array(
+        'payload-oxum'
+    );
+
+    /**
+     * Reserved element names for Bag-info fields.
+     */
+    const BAG_INFO_RESERVED_ELEMENTS = array(
+        'source-organization' => 'Source-Organization',
+        'organization-address' => 'Organization-Address',
+        'contact-name' => 'Contact-Name',
+        'contact-phone' => 'Contact-Phone',
+        'contact-email' => 'Contact-Email',
+        'external-description' => 'External-Description',
+        'bagging-date' => 'Bagging-Date',
+        'external-identifier' => 'External-Identifier',
+        'payload-oxum' => 'Payload-Oxum',
+        'bag-size' => 'Bag-Size',
+        'bag-group-identifier' => 'Bag-Group-Identifier',
+        'bag-count' => 'Bag-Count',
+        'internal-sender-identifier' => 'Internal-Sender-Identifier',
+        'internal-sender-description' => 'Internal-Sender-Description',
+    );
+}

--- a/lib/BagItUtils.php
+++ b/lib/BagItUtils.php
@@ -361,9 +361,6 @@ class BagItUtils
         if ($success) {
             $major=(int)$matches[1];
             $minor=(int)$matches[2];
-            if ($major === null || $minor === null) {
-                throw new BagItException("Invalid bagit version: '{$matches[0]}'.");
-            }
             return array('major'=>$major, 'minor'=>$minor);
         }
 

--- a/test/BagItUtilsTest.php
+++ b/test/BagItUtilsTest.php
@@ -703,63 +703,12 @@ class BagItUtilsTest extends BagItTestCase
      */
     public function testValidateExistsFail()
     {
-        $errors = array();
+        $errors=array();
         $this->assertFalse(
             BagItUtils::validateExists(__DIR__ . '/not-here', $errors)
         );
         $this->assertEquals(1, count($errors));
         $this->assertEquals('not-here', $errors[0][0]);
         $this->assertEquals('not-here does not exist.', $errors[0][1]);
-    }
-
-    /**
-     * @group BagItUtils
-     * @covers ::parseBagInfo
-     */
-    public function testParseBaseInfoEmptyLine()
-    {
-        $lines = array(
-            'some: here',
-            '',
-            'other: there'
-        );
-
-        $info = BagItUtils::parseBagInfo($lines);
-        $this->assertEquals('here', $info['some']);
-        $this->assertEquals('there', $info['other']);
-    }
-
-    /**
-     * @group BagItUtils
-     * @covers ::parseBagInfo
-     */
-    public function testParseBaseInfoContinued()
-    {
-        $lines = array(
-            'some: here',
-            ' and there',
-            'other: there',
-            "\tand here"
-        );
-
-        $info = BagItUtils::parseBagInfo($lines);
-        $this->assertEquals('here and there', $info['some']);
-        $this->assertEquals('there and here', $info['other']);
-    }
-
-    /**
-     * @group BagItUtils
-     * @covers ::parseBagInfo
-     */
-    public function testParseBaseInfoStandard()
-    {
-        $lines = array(
-            'some: here',
-            'other: there'
-        );
-
-        $info = BagItUtils::parseBagInfo($lines);
-        $this->assertEquals('here', $info['some']);
-        $this->assertEquals('there', $info['other']);
     }
 }

--- a/test/BagItUtilsTest.php
+++ b/test/BagItUtilsTest.php
@@ -711,4 +711,42 @@ class BagItUtilsTest extends BagItTestCase
         $this->assertEquals('not-here', $errors[0][0]);
         $this->assertEquals('not-here does not exist.', $errors[0][1]);
     }
+
+    /**
+     * Test for not repeating non-repeatable fields.
+     * @group BagItUtils
+     * @covers ::checkForNonRepeatableBagInfoFields
+     * @covers ::arrayKeyExistsNoCase
+     */
+    public function testNonRepeatableFieldsSuccess()
+    {
+        $bagInfo = [
+            'Source-organization' => 'Some place',
+            'Contact-name' => 'Jim Smith',
+            'Contact-email' => 'jsmith@noreply.com',
+        ];
+        BagItUtils::checkForNonRepeatableBagInfoFields('source-organization', $bagInfo);
+        BagItUtils::checkForNonRepeatableBagInfoFields('My-ID', $bagInfo);
+        BagItUtils::checkForNonRepeatableBagInfoFields('payload-oxum', $bagInfo);
+    }
+
+    /**
+     * Test for not repeating non-repeatable fields.
+     * @group BagItUtils
+     * @covers ::checkForNonRepeatableBagInfoFields
+     * @covers ::arrayKeyExistsNoCase
+     * @expectedException \ScholarsLab\BagIt\BagItException
+     */
+    public function testNonRepeatableFieldsFailure()
+    {
+        $bagInfo = [
+            'Source-organization' => 'Some place',
+            'Contact-name' => 'Jim Smith',
+            'Contact-email' => 'jsmith@noreply.com',
+            'Payload-oxum' => '123456',
+        ];
+        BagItUtils::checkForNonRepeatableBagInfoFields('source-organization', $bagInfo);
+        BagItUtils::checkForNonRepeatableBagInfoFields('My-ID', $bagInfo);
+        BagItUtils::checkForNonRepeatableBagInfoFields('payload-oxum', $bagInfo);
+    }
 }


### PR DESCRIPTION
Throw error if you try to set payload-oxum twice

Now if you load a `bag-info.txt` with various case of the reserved element names from the specification they are converted to a local static case defined in `BagItConstants`. But also no matter what case you try to search, retrieve or set Bag Info information with they are coverted to the static case. 

So `hasBagInfoData("SOURCE-ORGANIZATION")` and `hasBagInfoData("source-organization")` both are converted to search for the expected case of `hasBagInfoData("Source-Organization")` and will retrieve the field.

This is also true for `getBagInfoData($key)` and `setBagInfoData($key, $value)`.

But if you define other metadata elements (like `My-Metadata` for example) the case is preserved and you only match on the exact case.
